### PR TITLE
Fix preact/hooks import to share preact instance

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
       {
         "imports": {
           "preact": "https://esm.sh/preact@10.25.4",
-          "preact/hooks": "https://esm.sh/preact@10.25.4/hooks?external=/preact",
+          "preact/hooks": "https://esm.sh/preact@10.25.4/hooks?deps=preact@10.25.4",
           "htm/preact": "https://esm.sh/htm@3.1.1/preact?external=preact",
           "ramda": "https://esm.sh/ramda@0.30.1"
         }


### PR DESCRIPTION
## Summary
- esm.sh's `preact/hooks` build with `external=/preact` started failing with `Cannot read properties of undefined (reading '__H')` — the externalized hooks expect an `options` export the default `preact` entry doesn't provide, so hooks ran against an undefined internal state object.
- Switched to `?deps=preact@10.25.4`, which builds hooks against a matching preact version while the import map keeps both URLs pointing at the same instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)